### PR TITLE
FABRIC-6527 | Port IDP - Update Team Title with Identifier in port.yml;  Add repo lifecycle in port.yml

### DIFF
--- a/port.yml
+++ b/port.yml
@@ -1,15 +1,17 @@
 identifier: kendo-ui-webpack
 title: kendo-ui-webpack
 blueprint: service
-team: ["Professional Archive PCweb"]
+team: ["professional_archive_p_cweb"]
 properties:
-  description: "CommonJS proxy for kendo-ui-core" 
+  description: "CommonJS proxy for kendo-ui-core"
   customer_facing: false
   monitor_dashboards: ["https://app.datadoghq.com/dashboard/red-mq8-s2v/pro-archive-platform-ui-health"]
   logs: ["https://splunk.smarshinc.com/en-US/app/search/search?earliest=-15m&latest=now&q=search%20index%3D%22smc_index%22&sid=1744042227.95636&display.page.search.mode=smart&dispatch.sample_ratio=1"]
   vault: ["https://smarsh1.1password.com"]
   documentation: ["https://smarsh.atlassian.net/wiki/spaces/DEV/pages/1291863/Pro+Archive+UI+Team"]
   repo_type: library
+  lifecycle: "production"
 relations:
-    product: "professional_archive"
-    code_owners: ["ben.simmons@smarsh.com", "brittnee.nunn@smarsh.com", "matthew.pietz@smarsh.com", "mckella.laurence@smarsh.com", "shelly.liabraaten@smarsh.com", "justin.parker@smarsh.com"]
+  product: "professional_archive"
+  code_owners: ["ben.simmons@smarsh.com", "brittnee.nunn@smarsh.com", "matthew.pietz@smarsh.com", "mckella.laurence@smarsh.com",
+    "shelly.liabraaten@smarsh.com", "justin.parker@smarsh.com"]


### PR DESCRIPTION
This PR updates the team field in port.yml to use the Port IDP team identifier also adds the repo lifecycle.